### PR TITLE
Refactor compression utils and modernize registration

### DIFF
--- a/compression_utils.py
+++ b/compression_utils.py
@@ -1,0 +1,45 @@
+import zlib
+import struct
+import logging
+import bpy
+
+
+def unzlib(input_path, temp_path, pes_version):
+    """Decompress binary data used in PES files."""
+    logging.debug("Starting unzlib")
+    with open(input_path, 'rb') as data:
+        data.seek(16)
+        if pes_version in {"pes_pc", "pes_ps2", "pes_psp"}:
+            data.seek(16, 1)
+        raw_data = data.read()
+    decompressed = zlib.decompress(raw_data, 32)
+    with open(temp_path, 'wb') as out:
+        out.write(decompressed)
+    logging.debug("Finishing unzlib")
+    return open(temp_path, 'rb')
+
+
+def zlib_comp(temp_path, output_path, pes_version, tool_id):
+    """Compress binary data back to PES format."""
+    logging.debug("Starting zlib")
+    exp1 = open(temp_path, 'rb').read()
+    exp2 = zlib.compress(exp1, 9)
+    with open(output_path, 'wb') as exp:
+        if pes_version == 'pes13':
+            exp.write(struct.pack('I', 0x57010100))
+            exp.write(struct.pack('4s', b'ESYS'))
+        else:
+            exp.write(struct.pack('I', 0x00010600))
+        exp.write(struct.pack('I', len(exp2)))
+        exp.write(struct.pack('I', len(exp1)))
+        if pes_version in {'pes_pc', 'pes_ps2', 'pes_psp'}:
+            exp.write(struct.pack('20s', b''))
+        exp.write(exp2)
+        copyright = "Made by Suat CAGDAS 'sxsxsx'"
+        if pes_version in {'pes_pc', 'pes_ps2', 'pes_psp'}:
+            exp.write(struct.pack('16s', b''))
+            copyright = 'Made by PES Indie Team'
+        exp.write(struct.pack('I%dsI%ds' % (len(tool_id), len(copyright)),
+                              0, tool_id.encode(), 0, copyright.encode()))
+    logging.debug("Finishing zlib")
+

--- a/compression_utils.py
+++ b/compression_utils.py
@@ -1,15 +1,26 @@
 import zlib
 import struct
 import logging
+from typing import Union
+
 import bpy
+from versions import PESVersion, PES_VERSIONS
+
+
+def _get_version(version: Union[str, PESVersion]) -> PESVersion:
+    """Return the :class:`PESVersion` instance for ``version``."""
+    if isinstance(version, PESVersion):
+        return version
+    return PES_VERSIONS[version]
 
 
 def unzlib(input_path, temp_path, pes_version):
     """Decompress binary data used in PES files."""
+    version = _get_version(pes_version)
     logging.debug("Starting unzlib")
     with open(input_path, 'rb') as data:
         data.seek(16)
-        if pes_version in {"pes_pc", "pes_ps2", "pes_psp"}:
+        if version.extra_skip:
             data.seek(16, 1)
         raw_data = data.read()
     decompressed = zlib.decompress(raw_data, 32)
@@ -21,25 +32,29 @@ def unzlib(input_path, temp_path, pes_version):
 
 def zlib_comp(temp_path, output_path, pes_version, tool_id):
     """Compress binary data back to PES format."""
+    version = _get_version(pes_version)
     logging.debug("Starting zlib")
     exp1 = open(temp_path, 'rb').read()
     exp2 = zlib.compress(exp1, 9)
     with open(output_path, 'wb') as exp:
-        if pes_version == 'pes13':
-            exp.write(struct.pack('I', 0x57010100))
-            exp.write(struct.pack('4s', b'ESYS'))
-        else:
-            exp.write(struct.pack('I', 0x00010600))
+        exp.write(struct.pack('I', version.header))
+        if version.esys:
+            exp.write(struct.pack('4s', version.esys))
         exp.write(struct.pack('I', len(exp2)))
         exp.write(struct.pack('I', len(exp1)))
-        if pes_version in {'pes_pc', 'pes_ps2', 'pes_psp'}:
+        if version.extra_padding:
             exp.write(struct.pack('20s', b''))
         exp.write(exp2)
-        copyright = "Made by Suat CAGDAS 'sxsxsx'"
-        if pes_version in {'pes_pc', 'pes_ps2', 'pes_psp'}:
+        if version.extra_padding:
             exp.write(struct.pack('16s', b''))
-            copyright = 'Made by PES Indie Team'
-        exp.write(struct.pack('I%dsI%ds' % (len(tool_id), len(copyright)),
-                              0, tool_id.encode(), 0, copyright.encode()))
+        exp.write(
+            struct.pack(
+                'I%dsI%ds' % (len(tool_id), len(version.copyright)),
+                0,
+                tool_id.encode(),
+                0,
+                version.copyright.encode(),
+            )
+        )
     logging.debug("Finishing zlib")
 

--- a/pes_face_modifier.py
+++ b/pes_face_modifier.py
@@ -16,6 +16,7 @@ import os
 import struct
 import io
 import compression_utils
+import versions
 from array import array
 from bpy.props import *
 import logging
@@ -77,7 +78,7 @@ def unzlib(model):
     return compression_utils.unzlib(
         filepath_imp,
         temp,
-        bpy.context.scene.pes_ver,
+        versions.PES_VERSIONS[bpy.context.scene.pes_ver],
     )
 
 def zlib_comp(self, model):
@@ -92,7 +93,7 @@ def zlib_comp(self, model):
     compression_utils.zlib_comp(
         temp,
         filepath_exp,
-        bpy.context.scene.pes_ver,
+        versions.PES_VERSIONS[bpy.context.scene.pes_ver],
         tool_id,
     )
 

--- a/pes_face_modifier.py
+++ b/pes_face_modifier.py
@@ -2,8 +2,7 @@ bl_info = {
     "name": "PES/WE/JL PC/PS2/PSP and PES2013 PC Face/Hair Modifier Tool",
     "author": "PES Indie Team / Suat CAGDAS  'sxsxsx'",
     "version": (2,0),
-    "blender": (2, 6, 7),
-    "api": 35853,
+    "blender": (2, 80, 0),
     "location": "Under Scene Tab",
     "description": "Import/Export PES/WE/JL PC/PS2/PSP and PES13 PC Face/Hair Model",
     "warning": "",
@@ -11,7 +10,12 @@ bl_info = {
     "tracker_url": "",
     "category": "System"}
 
-import bpy,bmesh,zlib,os,struct,io
+import bpy
+import bmesh
+import os
+import struct
+import io
+import compression_utils
 from array import array
 from bpy.props import *
 import logging
@@ -62,63 +66,35 @@ class VertexGroup():
         self.total_faces = total_faces
 
 def unzlib(model):
-    logging.debug("Starting unzlib")
+    """Wrapper to decompress selected model using compression_utils."""
     if model == 'face':
-        filepath_imp=facepath
-        temp=face_temp
+        filepath_imp = facepath
+        temp = face_temp
     else:
-        filepath_imp=hairpath
-        temp=hair_temp
-        
-    data1 = open(filepath_imp, 'rb')
-    data1.seek(16,0)
-    if bpy.context.scene.pes_ver == "pes_pc" or bpy.context.scene.pes_ver == "pes_ps2" or bpy.context.scene.pes_ver == "pes_psp":
-        data1.seek(16,1)  
-    data2=data1.read()
-    data3=zlib.decompress(data2,32)
-    out=open(temp,"wb")
-    out.write(data3)
-    out.flush()
-    out.close()
+        filepath_imp = hairpath
+        temp = hair_temp
 
-    logging.debug("Finishing unzlib")
+    return compression_utils.unzlib(
+        filepath_imp,
+        temp,
+        bpy.context.scene.pes_ver,
+    )
 
-    return open(temp,"rb")
-
-def zlib_comp(self,model):
-    logging.debug("Starting zlib")
-
+def zlib_comp(self, model):
+    """Wrapper to compress selected model using compression_utils."""
     if model == 'face':
-        filepath_exp=facepath
-        temp=face_temp
+        filepath_exp = facepath
+        temp = face_temp
     else:
-        filepath_exp=hairpath
-        temp=hair_temp
-    
-    exp1=open(temp, 'rb').read()
-    exp2=zlib.compress(exp1,9)
-    s1,s2=len(exp1),len(exp2)
-    exp=open(filepath_exp,"wb")
-    if bpy.context.scene.pes_ver == 'pes13':
-        exp.write(struct.pack("I",0x57010100))
-        exp.write(struct.pack("4s","ESYS".encode()))
-    else:
-        exp.write(struct.pack("I",0x00010600))
-    exp.write(struct.pack("I",s2))
-    exp.write(struct.pack("I",s1))
-    if bpy.context.scene.pes_ver == "pes_pc" or bpy.context.scene.pes_ver == "pes_ps2" or bpy.context.scene.pes_ver == "pes_psp":
-        exp.write(struct.pack("20s","".encode()))
-    exp.write(exp2)
-    copyright = "Made by Suat CAGDAS 'sxsxsx'"
-    if bpy.context.scene.pes_ver == "pes_pc" or bpy.context.scene.pes_ver == "pes_ps2" or bpy.context.scene.pes_ver == "pes_psp":
-        exp.write(struct.pack("16s","".encode()))
-        copyright = "Made by PES Indie Team"
-    exp.write(struct.pack("I%dsI%ds" % (len(tool_id), len(copyright)),0,
-                              tool_id.encode(),
-                              0,copyright.encode()))
-    exp.flush()
-    exp.close()
-    logging.debug("Finishing zlib")
+        filepath_exp = hairpath
+        temp = hair_temp
+
+    compression_utils.zlib_comp(
+        temp,
+        filepath_exp,
+        bpy.context.scene.pes_ver,
+        tool_id,
+    )
 
 def pes_psp_exp(self,model):
     
@@ -1826,13 +1802,19 @@ class Face_Modifier_OP(bpy.types.Operator):
             bpy.context.scene.hair_path=bpy.context.scene.ks_path+hair_id
             return {'FINISHED'}
 
+
+classes = (
+    Face_Modifier_PA,
+    Face_Modifier_OP,
+)
+
 def register():
-    bpy.utils.register_module(__name__)
-    pass
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 def unregister():
-    bpy.utils.unregister_module(__name__)
-    pass
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
 if __name__ == "__main__":
     register()

--- a/versions.py
+++ b/versions.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class PESVersion:
+    code: str
+    header: int
+    esys: bytes = b''
+    extra_skip: bool = False
+    extra_padding: bool = False
+    copyright: str = "Made by Suat CAGDAS 'sxsxsx'"
+
+# Define supported game versions
+PES_VERSIONS = {
+    'pes13': PESVersion(
+        code='pes13',
+        header=0x57010100,
+        esys=b'ESYS',
+    ),
+    'pes_pc': PESVersion(
+        code='pes_pc',
+        header=0x00010600,
+        extra_skip=True,
+        extra_padding=True,
+        copyright='Made by PES Indie Team',
+    ),
+    'pes_ps2': PESVersion(
+        code='pes_ps2',
+        header=0x00010600,
+        extra_skip=True,
+        extra_padding=True,
+        copyright='Made by PES Indie Team',
+    ),
+    'pes_psp': PESVersion(
+        code='pes_psp',
+        header=0x00010600,
+        extra_skip=True,
+        extra_padding=True,
+        copyright='Made by PES Indie Team',
+    ),
+}


### PR DESCRIPTION
## Summary
- move compression routines into `compression_utils.py`
- wrap old functions around the new helpers
- update addon `bl_info` for Blender 2.80
- modernize register/unregister logic

## Testing
- `python -m py_compile pes_face_modifier.py compression_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684f701141c08324951e4b4e3e518fae